### PR TITLE
mine blocks with transactions which throws errors

### DIFF
--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -411,6 +411,8 @@ Blockchain.prototype.processTransaction = function(from, rawTx, callback) {
       block: block,
       generate: true
     }, function(err, results) {
+      self.mine();
+      
       if (err) {
         callback(err);
         return;
@@ -480,7 +482,6 @@ Blockchain.prototype.processTransaction = function(from, rawTx, callback) {
       self.logger.log("  Gas usage: " + utils.bufferToInt(self.toHex(tx_result.gasUsed)));
       self.logger.log("");
 
-      self.mine();
 
       callback(null, tx_hash);
     });


### PR DESCRIPTION
otherwise transactions are kept in the block and the nonce get
incremented which causes a nonce mismatch in further transactions and a
broken state
